### PR TITLE
fix "view raw script..." link in script_page.html

### DIFF
--- a/templates/script_page.html
+++ b/templates/script_page.html
@@ -14,7 +14,7 @@
 <strong><a href="index.html">&larr; back to main script listing</a></strong><br>
 
 <h2>{{ script_name }}</h2>
-<small>(<a href="raw/{{ script_name }}.txt">view raw script w/o annotations or w/e</a>)</small>
+<small>(<a href="/raw/{{ chapter }}/{{ script_name }}.txt">view raw script w/o annotations or w/e</a>)</small>
 
 <table class="code">
     {% for line in lines %}


### PR DESCRIPTION
currently clicking "_view raw script w/o annotations or w/e_" gives a 404 error. 

for example it would send you to: 
/ch1/raw/gml_GlobalScript_0.txt (doesn't exist)
instead of 
/raw/ch1/gml_GlobalScript_0.txt


**NOTE:** I'm not that good at coding stuff like this (and using github in general) so im not sure if im doing this correctly, i just found a bug using this program and i believe this would fix it