### PR TITLE
Support searching translated text in UT and DR ch1

### DIFF
--- a/index.py
+++ b/index.py
@@ -103,6 +103,26 @@ def process_scripts(data: Data, decompiled_dir: Path) -> ScriptIndex:
     return index
 
 
+def annotate_line(line: str, data: Data) -> str:
+    def quote(string: str) -> str:
+        if data.game == 'undertale':
+            # Undertale's decompiled GML doesn't use backslash escapes.
+            # But for nested quotes this is easier/more readable.
+            return '"' + string.replace('"', '\\"') + '"'
+        return json.dumps(string, ensure_ascii=False)
+
+    keys: list[str] = re.findall(
+        r'scr_(?:84_get_lang_string(?:_ch1)?|gettext)\("([a-zA-Z0-9_-]+)"\)',
+        line,
+        flags=re.IGNORECASE,
+    )
+    if keys:
+        line += ' // ' + ', '.join(
+            quote(data.get_localized_string_ch1(key)) for key in keys
+        )
+    return line
+
+
 def write_index(index: ScriptIndex, data: Data, output_dir: Path) -> None:
     with open(output_dir / 'index.html', 'w', encoding='utf-8') as f:
         env = Environment(loader=FileSystemLoader('templates'))
@@ -116,7 +136,14 @@ def write_index(index: ScriptIndex, data: Data, output_dir: Path) -> None:
             )
         )
     with open(output_dir / 'index.json', 'w', encoding='utf-8') as f:
-        json.dump(index.text, f, separators=(',', ':'))
+        json.dump(
+            {
+                filename: [annotate_line(line, data) for line in lines]
+                for filename, lines in index.text.items()
+            },
+            f,
+            separators=(',', ':'),
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
For translation functions where the English translation doesn't appear inline where it's used add it as a code comment in the search index.

We already display it on the script page so we don't need it there.

Examples:
<img width="1049" height="159" alt="image" src="https://github.com/user-attachments/assets/304e205c-4c7f-4dfc-94c1-3517264698ab" />
<img width="854" height="216" alt="image" src="https://github.com/user-attachments/assets/c368ba98-9726-4195-ab72-0a683e1c5bca" />
<img width="842" height="156" alt="image" src="https://github.com/user-attachments/assets/0dee362c-5a74-44b0-ac16-901b381c01cd" />
