### PR TITLE
feat: parse flag function argument as a flag

### DIFF
--- a/script.py
+++ b/script.py
@@ -253,7 +253,7 @@ def process_line(
     )
     # Highlight flags, rooms and enemies
     line = re.sub(
-        r'(global\.flag\[)(\d+)(\])',
+        r'(global\.flag\[|scr_flag_get\()(\d+)(\]|\))',
         lambda matches: highlight_flag(matches, data),
         line,
         flags=re.IGNORECASE,

--- a/script.py
+++ b/script.py
@@ -253,7 +253,7 @@ def process_line(
     )
     # Highlight flags, rooms and enemies
     line = re.sub(
-        r'(global\.flag\[|scr_flag_get\()(\d+)(\]|\))',
+        r'(global\.flag\[|scr_flag_(?:g|s)et(?:_ext)?\()(\d+)((?:, .+?)?(?:\]|\)))',  # noqa: E501
         lambda matches: highlight_flag(matches, data),
         line,
         flags=re.IGNORECASE,


### PR DESCRIPTION
Fixes #23.

Processes the first argument as a flag for the following functions:
- `scr_flag_get`
- `scr_flag_set`
- `scr_flag_get_ext`
- `scr_flag_set_ext`

Additional arguments are preserved but not processed in any way.