### PR TITLE
fix: properly parse multiple localized strings on the same line

### DIFF
--- a/script.py
+++ b/script.py
@@ -246,13 +246,19 @@ def process_line(
 
     # Highlight localized strings
     line = re.sub(
-        r'([a-z0-9_]+loc\((?:\d+, )?)"((?:[^"\\]|\\.)+)(", (?:.+, )?"[a-z0-9_-]+")\)',  # noqa: E501
+        r'([a-z0-9_]+loc\((?:\d+, )?)"((?:[^"\\]|\\.)+)(", "[a-z0-9_-]+")\)',
         lambda matches: matches[1] + highlight_text(matches) + ')',
         line,
         flags=re.IGNORECASE,
     )
     line = re.sub(
-        r'(scr_(?:84_get_lang_string(?:_ch1)?|gettext)\(")([a-z0-9_-]+)("\))',  # noqa: E501
+        r'([a-z0-9_]+subloc\((?:\d+, )?)"((?:[^"\\]|\\.)+)(", (?:.+, )?"[a-z0-9_-]+")\)',  # noqa: E501
+        lambda matches: matches[1] + highlight_text(matches) + ')',
+        line,
+        flags=re.IGNORECASE,
+    )
+    line = re.sub(
+        r'(scr_(?:84_get_lang_string(?:_ch1)?|gettext)\(")([a-z0-9_-]+)("\))',
         lambda matches: highlight_text_ch1(matches, data),
         line,
         flags=re.IGNORECASE,


### PR DESCRIPTION
I've messed up in my previous pull request and broke parsing for multiple localized strings located on the same line, example: https://code.deltarune.wiki/ch2/gml_globalscript_scr_text#L3248

This should fix parsing for **non-interpolated** strings, fixing interpolated strings would require proper syntax grammar (and there are no such cases in Deltarune code anyway).