### PR TITLE
feat: add related scripts section

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -134,6 +134,16 @@ def generate(game: str):
 
             index = process_scripts(data, decompiled_dir_ch)
 
+            related = {}
+
+            for section in index.sections.values():
+                if section.name == "Scripts": continue
+
+                for entries in section.entries.values():
+                    names = [entry.name for entry in entries]
+                    for entry in entries:
+                        related[entry.name] = names            
+
             logger.info(f"['{chapter}'] Rendering index...")
 
             write_index(index, data, output_dir_ch)
@@ -141,7 +151,7 @@ def generate(game: str):
             logger.info(f"['{chapter}'] Rendering scripts' pages...")
 
             for script in tqdm(index.text.keys(), disable=None):
-                rendered = render_script(script, index.text, data)
+                rendered = render_script(script, index.text, data, related.get(script, []))
 
                 write_script(rendered, script, output_dir_ch)
 
@@ -157,6 +167,16 @@ def generate(game: str):
 
         index = process_scripts(data, decompiled_dir)
 
+        related = {}
+
+        for section in index.sections.values():
+            if section.name == "Scripts": continue
+
+            for entries in section.entries.values():
+                rel_entries = [entry for entry in entries]
+                for entry in entries:
+                    related[entry.name] = rel_entries        
+
         logger.info('Rendering index...')
 
         write_index(index, data, output_dir)
@@ -164,7 +184,7 @@ def generate(game: str):
         logger.info("Rendering scripts' pages...")
 
         for script in tqdm(index.text.keys(), disable=None):
-            rendered = render_script(script, index.text, data)
+            rendered = render_script(script, index.text, data, related.get(script, []))
 
             write_script(rendered, script, output_dir)
 

--- a/generate.py
+++ b/generate.py
@@ -137,12 +137,13 @@ def generate(game: str):
             related = {}
 
             for section in index.sections.values():
-                if section.name == "Scripts": continue
+                if section.name == 'Scripts':
+                    continue
 
                 for entries in section.entries.values():
                     names = [entry.name for entry in entries]
                     for entry in entries:
-                        related[entry.name] = names            
+                        related[entry.name] = names
 
             logger.info(f"['{chapter}'] Rendering index...")
 
@@ -151,7 +152,12 @@ def generate(game: str):
             logger.info(f"['{chapter}'] Rendering scripts' pages...")
 
             for script in tqdm(index.text.keys(), disable=None):
-                rendered = render_script(script, index.text, data, related.get(script, []))
+                rendered = render_script(
+                    script,
+                    index.text,
+                    data,
+                    related.get(script, [])
+                )
 
                 write_script(rendered, script, output_dir_ch)
 
@@ -170,7 +176,8 @@ def generate(game: str):
         related = {}
 
         for section in index.sections.values():
-            if section.name == "Scripts": continue
+            if section.name == 'Scripts':
+                continue
 
             for entries in section.entries.values():
                 rel_entries = [entry for entry in entries]
@@ -184,7 +191,12 @@ def generate(game: str):
         logger.info("Rendering scripts' pages...")
 
         for script in tqdm(index.text.keys(), disable=None):
-            rendered = render_script(script, index.text, data, related.get(script, []))
+            rendered = render_script(
+                script,
+                index.text,
+                data,
+                related.get(script, [])
+            )
 
             write_script(rendered, script, output_dir)
 

--- a/script.py
+++ b/script.py
@@ -306,7 +306,7 @@ def process_line(
 
 
 def render_script(
-    script_name: str, text: Dict[str, List[str]], data: Data
+    script_name: str, text: Dict[str, List[str]], data: Data, related_scripts: Optional[List[str]] = []
 ) -> str:
     lines = [
         process_line(line, script_name, text, data)
@@ -320,9 +320,10 @@ def render_script(
         script_name=script_name,
         raw_url=f'/raw{chapter_segment}/{script_name}.txt',
         lines=lines,
+        related_scripts=related_scripts,
         game=data.get_game_name(),
         links=data.get_game_links(),
-        footer=data.get_game_footer(),
+        footer=data.get_game_footer()
     )
 
 

--- a/script.py
+++ b/script.py
@@ -5,7 +5,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 

--- a/script.py
+++ b/script.py
@@ -306,7 +306,10 @@ def process_line(
 
 
 def render_script(
-    script_name: str, text: Dict[str, List[str]], data: Data, related_scripts: Optional[List[str]] = []
+    script_name: str,
+    text: Dict[str, List[str]],
+    data: Data,
+    related_scripts: Optional[List[str]] = []
 ) -> str:
     lines = [
         process_line(line, script_name, text, data)

--- a/static/main.css
+++ b/static/main.css
@@ -49,6 +49,59 @@
 	--function-box-background-color: rgba(30, 50, 30, 0.9);
 }
 
+@media (prefers-color-scheme: light) {
+	:root {
+		--background: #111;
+		--secondary-background: #080808;
+		--text-color: #CCC;
+		--link-color: #8AD;
+		--link-hover-color: #ADF;
+		--border-color: #999;
+		--junk-text-color: #999;
+
+		--selected-line-background-color: #333;
+		--lang-var-text-color: #c7d;
+		--lang-var-background-color: black;
+		--lang-var-border-color: #836;
+		--lang-text-text-color: #fbe;
+		--lang-text-background-color: black;
+		--lang-text-border-color: #969;
+		--wait-background-color: #555;
+		--wait-text-color: #fff;
+		--delay-background-color: #111;
+		--delay-text-color: #666;
+		--delay-collapsed-text-color: #aaa;
+		--close-background-color: #844;
+		--close-text-color: #fff;
+		--face-background-color: #252;
+		--face-text-color: #8c8;
+		--arg-background-color: #707;
+		--arg-text-color: #fff;
+		--arg-collapsed-text-color: #aaa;
+		--flag-not-found-text-color: #ec6;
+		--flag-found-text-color: #fd8;
+		--flag-found-background-color: black;
+		--flag-description-text-color: #ca4;
+		--room-text-color: #8f8;
+		--room-background-color: black;
+		--room-description-text-color: #494;
+		--alarm-link-text-color: #faa;
+		--alarm-link-text-color--hover: white;
+		--alarm-link-underline-color: #a66;
+		--alarm-box-border-color: #888;
+		--alarm-box-background-color: #222;
+		--alarm-connection-line-color: #444;
+		--alarm-background-color--hover: #400;
+		--alarm-border-color--hover: #f88;
+		--function-link-text-color: #8f8;
+		--function-link-underline-color: #292;
+		--function-link-background-color--hover: #272;
+		--function-link-text-color--hover: white;
+		--function-box-border-color: #8f8;
+		--function-box-background-color: rgba(30, 50, 30, 0.9);
+	}
+}
+
 html, body {
 	width: 100%;
 	height: 100%;

--- a/templates/script_page.html
+++ b/templates/script_page.html
@@ -13,6 +13,22 @@
             <strong><a href="index.html">&larr; back to main script listing</a></strong><br>
 
             <h2>{{ script_name }}</h2>
+
+            {% if related_scripts is defined and related_scripts|length > 0 %}
+                <div>
+                    <strong>related scripts:</strong>
+                    {% for script in related_scripts %}
+                        {% if (script.prefix + script.suffix) == script_name %}
+                            <strong>{{ script.suffix }} </strong>
+                        {% else %}
+                            <a href="{{ script.url }}">{{ script.suffix }}</a>
+                        {% endif %}
+                        {% if not loop.last %} &bull; {% endif %}
+                    {% endfor %}
+                </div>
+                <br />
+            {% endif %}
+
             <small>(<a href="{{ raw_url }}">view raw script w/o annotations or w/e</a>)</small>
 
             <table class="code">


### PR DESCRIPTION
All scripts that share the same "owner" (i.e. object, room) now show up in a new "related scripts" section of the script viewer

<img width="771" height="216" alt="image" src="https://github.com/user-attachments/assets/bbc7978d-e62c-4478-994e-cd1dc1ee24ca" />

Closes #19.