### PR TITLE
feat: add related scripts section

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -134,6 +134,16 @@ def generate(game: str):
 
             index = process_scripts(data, decompiled_dir_ch)
 
+            related = {}
+
+            for section in index.sections.values():
+                if section.name == "Scripts": continue
+
+                for entries in section.entries.values():
+                    names = [entry.name for entry in entries]
+                    for entry in entries:
+                        related[entry.name] = names            
+
             logger.info(f"['{chapter}'] Rendering index...")
 
             write_index(index, data, output_dir_ch)
@@ -141,7 +151,7 @@ def generate(game: str):
             logger.info(f"['{chapter}'] Rendering scripts' pages...")
 
             for script in tqdm(index.text.keys(), disable=None):
-                rendered = render_script(script, index.text, data)
+                rendered = render_script(script, index.text, data, related.get(script, []))
 
                 write_script(rendered, script, output_dir_ch)
 
@@ -157,6 +167,16 @@ def generate(game: str):
 
         index = process_scripts(data, decompiled_dir)
 
+        related = {}
+
+        for section in index.sections.values():
+            if section.name == "Scripts": continue
+
+            for entries in section.entries.values():
+                rel_entries = [entry for entry in entries]
+                for entry in entries:
+                    related[entry.name] = rel_entries        
+
         logger.info('Rendering index...')
 
         write_index(index, data, output_dir)
@@ -164,7 +184,7 @@ def generate(game: str):
         logger.info("Rendering scripts' pages...")
 
         for script in tqdm(index.text.keys(), disable=None):
-            rendered = render_script(script, index.text, data)
+            rendered = render_script(script, index.text, data, related.get(script, []))
 
             write_script(rendered, script, output_dir)
 

--- a/generate.py
+++ b/generate.py
@@ -137,12 +137,13 @@ def generate(game: str):
             related = {}
 
             for section in index.sections.values():
-                if section.name == "Scripts": continue
+                if section.name == 'Scripts':
+                    continue
 
                 for entries in section.entries.values():
                     names = [entry.name for entry in entries]
                     for entry in entries:
-                        related[entry.name] = names            
+                        related[entry.name] = names
 
             logger.info(f"['{chapter}'] Rendering index...")
 
@@ -151,7 +152,12 @@ def generate(game: str):
             logger.info(f"['{chapter}'] Rendering scripts' pages...")
 
             for script in tqdm(index.text.keys(), disable=None):
-                rendered = render_script(script, index.text, data, related.get(script, []))
+                rendered = render_script(
+                    script,
+                    index.text,
+                    data,
+                    related.get(script, [])
+                )
 
                 write_script(rendered, script, output_dir_ch)
 
@@ -170,12 +176,13 @@ def generate(game: str):
         related = {}
 
         for section in index.sections.values():
-            if section.name == "Scripts": continue
+            if section.name == 'Scripts':
+                continue
 
             for entries in section.entries.values():
                 rel_entries = [entry for entry in entries]
                 for entry in entries:
-                    related[entry.name] = rel_entries        
+                    related[entry.name] = rel_entries
 
         logger.info('Rendering index...')
 
@@ -184,7 +191,12 @@ def generate(game: str):
         logger.info("Rendering scripts' pages...")
 
         for script in tqdm(index.text.keys(), disable=None):
-            rendered = render_script(script, index.text, data, related.get(script, []))
+            rendered = render_script(
+                script,
+                index.text,
+                data,
+                related.get(script, [])
+            )
 
             write_script(rendered, script, output_dir)
 

--- a/script.py
+++ b/script.py
@@ -306,7 +306,7 @@ def process_line(
 
 
 def render_script(
-    script_name: str, text: Dict[str, List[str]], data: Data
+    script_name: str, text: Dict[str, List[str]], data: Data, related_scripts: Optional[List[str]] = []
 ) -> str:
     lines = [
         process_line(line, script_name, text, data)
@@ -320,9 +320,10 @@ def render_script(
         script_name=script_name,
         raw_url=f'/raw{chapter_segment}/{script_name}.txt',
         lines=lines,
+        related_scripts=related_scripts,
         game=data.get_game_name(),
         links=data.get_game_links(),
-        footer=data.get_game_footer(),
+        footer=data.get_game_footer()
     )
 
 

--- a/script.py
+++ b/script.py
@@ -5,7 +5,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
@@ -306,7 +306,10 @@ def process_line(
 
 
 def render_script(
-    script_name: str, text: Dict[str, List[str]], data: Data, related_scripts: Optional[List[str]] = []
+    script_name: str,
+    text: Dict[str, List[str]],
+    data: Data,
+    related_scripts: Optional[List[str]] = []
 ) -> str:
     lines = [
         process_line(line, script_name, text, data)

--- a/templates/script_page.html
+++ b/templates/script_page.html
@@ -13,6 +13,22 @@
             <strong><a href="index.html">&larr; back to main script listing</a></strong><br>
 
             <h2>{{ script_name }}</h2>
+
+            {% if related_scripts is defined and related_scripts|length > 0 %}
+                <div>
+                    <strong>related scripts:</strong>
+                    {% for script in related_scripts %}
+                        {% if (script.prefix + script.suffix) == script_name %}
+                            <strong>{{ script.suffix }} </strong>
+                        {% else %}
+                            <a href="{{ script.url }}">{{ script.suffix }}</a>
+                        {% endif %}
+                        {% if not loop.last %} &bull; {% endif %}
+                    {% endfor %}
+                </div>
+                <br />
+            {% endif %}
+
             <small>(<a href="{{ raw_url }}">view raw script w/o annotations or w/e</a>)</small>
 
             <table class="code">


### PR DESCRIPTION
(part 2 electric boogaloo)

All scripts that share the same "owner" (i.e. object, room) now show up in a new "related scripts" section of the script viewer

<img width="771" height="216" alt="image" src="https://github.com/user-attachments/assets/bbc7978d-e62c-4478-994e-cd1dc1ee24ca" />

Closes #19.